### PR TITLE
implement support transactions to prevent invocation of default method

### DIFF
--- a/django_exabackend/features.py
+++ b/django_exabackend/features.py
@@ -9,3 +9,6 @@ except ImportError: pytz = None
 
 class DatabaseFeatures(BaseDatabaseFeatures):
     datetime_tz_cut = re.compile(r'^(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}[.]\d{6})[-+]\d{2}:\d{2}$')
+
+    def supports_transactions(self):
+        return True


### PR DESCRIPTION
it causes tests to fail during setUp because parent method tries to create a table, something that may not be possible in general (permissions, no open schema)

(solving #1)
