### PR TITLE
EXASOL ODBC driver doesn’t support unicode statements

### DIFF
--- a/django_exabackend/base.py
+++ b/django_exabackend/base.py
@@ -44,7 +44,7 @@ class CursorWrapper(object):
             #print '@@@ execute:', repr(query), repr(args)
             if args is None:
                 return self.cursor.execute(query)
-            return self.cursor.execute(query.replace('%s', '?'), args)
+            return self.cursor.execute(force_str(query.replace('%s', '?')), args)
         except Database.OperationalError as e:
             if e.args[0] in self.codes_for_integrityerror:
                 six.reraise(utils.IntegrityError, utils.IntegrityError(*tuple(e.args)), sys.exc_info()[2])
@@ -52,7 +52,7 @@ class CursorWrapper(object):
 
     def executemany(self, query, args):
         try:
-            return self.cursor.executemany(query, args)
+            return self.cursor.executemany(force_str(query), args)
         except Database.OperationalError as e:
             if e.args[0] in self.codes_for_integrityerror:
                 six.reraise(utils.IntegrityError, utils.IntegrityError(*tuple(e.args)), sys.exc_info()[2])


### PR DESCRIPTION
see (https://www.exasol.com/support/browse/EXA-10027 and https://github.com/expobrain/sqlalchemy_exasol/commit/2f408aa9c0998dbd3d19b1a1a3fc69c2a24acc0a)
need to force str encoding before passing the sql statement to the driver
