### PR TITLE
support for schema.table names and uppercase regular (non-quoted) identifiers

### DIFF
--- a/django_exabackend/operations.py
+++ b/django_exabackend/operations.py
@@ -20,7 +20,14 @@ class DatabaseOperations(BaseDatabaseOperations):
         return value
 
     def quote_name(self, name):
-        return '"%s"' % name.replace('"', '""')
+        """
+        Returns a quoted version of the given table, index or column name. Does
+        not quote the given name if it's already been quoted.
+        Supports schema.table form identifiers -> "schema"."table"
+        """
+        if name.startswith('"') and name.endswith('"'):
+            return name # Quoting once is enough.
+        return '.'.join(['%s%s%s' % ('"', piece.upper(), '"') for piece in name.split('.')])
 
     def bulk_insert_sql(self, fields, placeholder_rows):
         #print "@@@ bulk_insert_sql", repr(fields), repr(placeholder_rows)


### PR DESCRIPTION
1. table names annotated with schema name: schema.table
2. converts non-quoted identifiers to uppercase to follow rules documented in the “2.1.2 SQL identifiers” section of the EXA Solution User Manual 5.0.13
